### PR TITLE
Upgrade to Avalonia 12 + latest NuGet packages

### DIFF
--- a/AnimeJaNaiConfEditor/AnimeJaNaiConfEditor.csproj
+++ b/AnimeJaNaiConfEditor/AnimeJaNaiConfEditor.csproj
@@ -28,16 +28,14 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.13" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.13" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.5.1" />
+    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
     <PackageReference Include="HyperText.Avalonia" Version="11.0.0-rc1" />
-    <PackageReference Include="Material.Icons.Avalonia" Version="2.4.1" />
-    <PackageReference Include="ReactiveUI.Avalonia" Version="11.4.12" />
+    <PackageReference Include="Material.Icons.Avalonia" Version="3.0.2" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
     <!-- WMI (Win32_VideoController / Win32_Processor) for benchmark-submission hardware info -->
     <PackageReference Include="System.Management" Version="10.0.0" />

--- a/AnimeJaNaiConfEditor/App.axaml
+++ b/AnimeJaNaiConfEditor/App.axaml
@@ -14,7 +14,7 @@
 
   <Application.Styles>
     <materialIcons:MaterialIconStyles />
-    <sty:FluentAvaloniaTheme UseSystemFontOnWindows="True" />
+    <sty:FluentAvaloniaTheme />
     <!--<FluentTheme>
       <FluentTheme.Palettes>
         <ColorPaletteResources x:Key="Light" Accent="#ff0073cf" AltHigh="White" AltLow="White" AltMedium="White" AltMediumHigh="White" AltMediumLow="White" BaseHigh="Black" BaseLow="#ffcccccc" BaseMedium="#ff898989" BaseMediumHigh="#ff5d5d5d" BaseMediumLow="#ff737373" ChromeAltLow="#ff5d5d5d" ChromeBlackHigh="Black" ChromeBlackLow="#ffcccccc" ChromeBlackMedium="#ff5d5d5d" ChromeBlackMediumLow="#ff898989" ChromeDisabledHigh="#ffcccccc" ChromeDisabledLow="#ff898989" ChromeGray="#ff737373" ChromeHigh="#ffcccccc" ChromeLow="#ffececec" ChromeMedium="#ffe6e6e6" ChromeMediumLow="#ffececec" ChromeWhite="White" ListLow="#ffe6e6e6" ListMedium="#ffcccccc" RegionColor="#ffe6e6e6" />

--- a/AnimeJaNaiConfEditor/Views/MainWindow.axaml.cs
+++ b/AnimeJaNaiConfEditor/Views/MainWindow.axaml.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace AnimeJaNaiConfEditor.Views
 {
-    public partial class MainWindow : AppWindow
+    public partial class MainWindow : FAAppWindow
     {
         public MainWindow()
         {
@@ -75,7 +75,7 @@ namespace AnimeJaNaiConfEditor.Views
 
                     if (inPath != null)
                     {
-                        var td = new TaskDialog
+                        var td = new FATaskDialog
                         {
                             Title = "Confirm Full Conf Import",
                             ShowProgressBar = false,
@@ -83,19 +83,18 @@ namespace AnimeJaNaiConfEditor.Views
     inPath,
                             Buttons =
             {
-                TaskDialogButton.OKButton,
-                TaskDialogButton.CancelButton
+                FATaskDialogButton.OKButton,
+                FATaskDialogButton.CancelButton
             }
                         };
 
 
                         td.Closing += async (s, e) =>
                         {
-                            if ((TaskDialogStandardResult)e.Result == TaskDialogStandardResult.OK)
+                            if ((FATaskDialogStandardResult)e.Result == FATaskDialogStandardResult.OK)
                             {
                                 var deferral = e.GetDeferral();
 
-                                td.SetProgressBarState(0, TaskDialogProgressState.Indeterminate);
                                 td.ShowProgressBar = true;
                                 int value = 0;
 
@@ -150,7 +149,7 @@ namespace AnimeJaNaiConfEditor.Views
                         }
                         else
                         {
-                            var td = new TaskDialog
+                            var td = new FATaskDialog
                             {
                                 Title = "Confirm Profile Conf Import",
                                 ShowProgressBar = false,
@@ -158,19 +157,18 @@ namespace AnimeJaNaiConfEditor.Views
                                 inPath,
                                 Buttons =
                             {
-                                TaskDialogButton.OKButton,
-                                TaskDialogButton.CancelButton
+                                FATaskDialogButton.OKButton,
+                                FATaskDialogButton.CancelButton
                             }
                             };
 
 
                             td.Closing += async (s, e) =>
                             {
-                                if ((TaskDialogStandardResult)e.Result == TaskDialogStandardResult.OK)
+                                if ((FATaskDialogStandardResult)e.Result == FATaskDialogStandardResult.OK)
                                 {
                                     var deferral = e.GetDeferral();
 
-                                    td.SetProgressBarState(0, TaskDialogProgressState.Indeterminate);
                                     td.ShowProgressBar = true;
 
                                     await Task.Run(() =>
@@ -207,26 +205,25 @@ namespace AnimeJaNaiConfEditor.Views
                     }
                     else
                     {
-                        var td = new TaskDialog
+                        var td = new FATaskDialog
                         {
                             Title = "Confirm Profile Conf Import",
                             ShowProgressBar = false,
                             Content = $"The profile {vm.SelectedProfileToClone.ProfileName} will be cloned to the current profile {vm.CurrentSlot.ProfileName}. All configuration settings will be backed up and then all configuration settings for the current profile {vm.CurrentSlot.ProfileName} will be overwritten.",
                             Buttons =
                         {
-                            TaskDialogButton.OKButton,
-                            TaskDialogButton.CancelButton
+                            FATaskDialogButton.OKButton,
+                            FATaskDialogButton.CancelButton
                         }
                         };
 
 
                         td.Closing += async (s, e) =>
                         {
-                            if ((TaskDialogStandardResult)e.Result == TaskDialogStandardResult.OK)
+                            if ((FATaskDialogStandardResult)e.Result == FATaskDialogStandardResult.OK)
                             {
                                 var deferral = e.GetDeferral();
 
-                                td.SetProgressBarState(0, TaskDialogProgressState.Indeterminate);
                                 td.ShowProgressBar = true;
                                 int value = 0;
 
@@ -325,7 +322,7 @@ namespace AnimeJaNaiConfEditor.Views
             if (DataContext is not MainWindowViewModel vm) return;
 
             const string runResult = "run";
-            var td = new TaskDialog
+            var td = new FATaskDialog
             {
                 Title = "Run playback benchmark",
                 Content = new TextBlock
@@ -342,8 +339,8 @@ namespace AnimeJaNaiConfEditor.Views
                 },
                 Buttons =
                 {
-                    new TaskDialogButton("Start benchmark", runResult),
-                    TaskDialogButton.CancelButton,
+                    new FATaskDialogButton("Start benchmark", runResult),
+                    FATaskDialogButton.CancelButton,
                 },
             };
             td.XamlRoot = VisualRoot as Visual;
@@ -452,15 +449,15 @@ namespace AnimeJaNaiConfEditor.Views
             panel.Children.Add(note);
 
             const string submitResult = "submit";
-            var td = new TaskDialog
+            var td = new FATaskDialog
             {
                 Title = "Submit benchmark to community catalog",
                 Content = panel,
                 ShowProgressBar = false,
                 Buttons =
                 {
-                    new TaskDialogButton("Submit", submitResult),
-                    TaskDialogButton.CancelButton,
+                    new FATaskDialogButton("Submit", submitResult),
+                    FATaskDialogButton.CancelButton,
                 },
             };
 
@@ -470,7 +467,6 @@ namespace AnimeJaNaiConfEditor.Views
                 if (!Equals(ev.Result, submitResult)) return;
                 var deferral = ev.GetDeferral();
                 td.ShowProgressBar = true;
-                td.SetProgressBarState(0, TaskDialogProgressState.Indeterminate);
                 outcome = await sub.SubmitAsync();   // sub's name/note are kept current by SubmitDialogModel
                 deferral.Complete();
             };
@@ -509,11 +505,11 @@ namespace AnimeJaNaiConfEditor.Views
 
         private async Task ShowInfoDialog(string title, string message)
         {
-            var td = new TaskDialog
+            var td = new FATaskDialog
             {
                 Title = title,
                 Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap, MaxWidth = 460 },
-                Buttons = { TaskDialogButton.OKButton },
+                Buttons = { FATaskDialogButton.OKButton },
             };
             td.XamlRoot = VisualRoot as Visual;
             await td.ShowAsync();


### PR DESCRIPTION
Brings the Manager to **Avalonia 12** + current packages, mirroring the VideoJaNai Av12 upgrade.

## Package versions
| Package | 11.x | 12 |
|---|---|---|
| Avalonia (+Desktop/Themes.Fluent/Fonts.Inter) | 11.3.13 | **12.0.4** |
| FluentAvaloniaUI | 2.5.1 | **3.0.0-preview4** |
| Material.Icons.Avalonia | 2.4.1 | **3.0.2** |
| ReactiveUI.Avalonia | 11.4.12 | **12.0.3** |
| Avalonia.Diagnostics | 11.3.13 (Debug) | **removed** (no 12.x; VideoJaNai dropped it) |
| HyperText.Avalonia | 11.0.0-rc1 | kept (runs on Av12 per VideoJaNai) |

## FluentAvalonia 3.0 breaking-change fixes (`Views/MainWindow.axaml.cs`, `App.axaml`)
- `TaskDialog` / `TaskDialogButton` / `TaskDialogStandardResult` → `FATaskDialog*` (6 dialogs)
- removed `SetProgressBarState(...)` (gone in FA3; `ShowProgressBar = true` is enough)
- `MainWindow : AppWindow` → `: FAAppWindow`
- `App.axaml`: dropped `UseSystemFontOnWindows` from `FluentAvaloniaTheme` (font comes from `WithInterFont`; matches VideoJaNai's `<sty:FluentAvaloniaTheme />`)

## Deliberately not changed (subset of VideoJaNai)
No drag-drop, suspension host, Autofac/Splat, or Velopack in this app, so those VideoJaNai changes don't apply. `UseReactiveUI(_ => {})` callback form is unchanged. `FAComboBox` and `StorageProvider` file pickers are unchanged — verified against VideoJaNai's working Av12 build.

## Verification
No PR-CI build and it can't compile on Linux (`win-x64` + `System.Management`), so **build on Windows** (`dotnet publish -r win-x64`, or run `release.yml`) is the real check. Then smoke-test: window opens (FAAppWindow), the editable `FAComboBox` dropdowns work, each TaskDialog (import conf / import profile / export / benchmark warning / submit-to-catalog) opens with OK/Cancel + progress-bar path, file pickers open, Material icons + hyperlinks render.

Watch points the build will surface if anything shifted in FA3-preview: the `new FATaskDialogButton(text, result)` constructor, Material.Icons 3.0 `MaterialIcon`/`MaterialIconStyles`, and the FA3 `FluentAvaloniaTheme` element.